### PR TITLE
Rename CLI to struct

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "cli",
+  "name": "standard-structure",
   "version": "0.0.1",
-  "description": "cli CLI",
+  "description": "The Standard-Structure library + CLI",
   "private": true,
   "types": "build/types/types.d.ts",
   "bin": {
-    "cli": "bin/cli"
+    "struct": "bin/cli"
   },
   "scripts": {
     "format": "prettier --write **/*.{js,ts,tsx,json}",


### PR DESCRIPTION
I renamed the global command to `struct`, and the package name to `standard-structure`. I also set a package description.