### PR TITLE
Correct network-check unit testing to proper directory

### DIFF
--- a/__tests__/network-check.test.ts
+++ b/__tests__/network-check.test.ts
@@ -1,0 +1,7 @@
+const { isNetworkConnected } = require("../src/struct/index");
+
+test("makes sure that we can tell that our unit tests run somewhere with Internet connection", async () => {
+  expect(await isNetworkConnected()).toBe(true);
+});
+
+export {};

--- a/__tests__/network-check.test.ts
+++ b/__tests__/network-check.test.ts
@@ -1,7 +1,7 @@
-const { isNetworkConnected } = require("../src/struct/index");
+const { isNetworkConnected } = require('../src/struct/index')
 
-test("makes sure that we can tell that our unit tests run somewhere with Internet connection", async () => {
-  expect(await isNetworkConnected()).toBe(true);
-});
+test('makes sure that we can tell that our unit tests run somewhere with Internet connection', async () => {
+  expect(await isNetworkConnected()).toBe(true)
+})
 
-export {};
+export {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -557,9 +557,10 @@
       }
     },
     "@types/node": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-      "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
+      "version": "12.12.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
+      "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg==",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -1251,9 +1252,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-      "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cli",
+  "name": "standard-structure",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -557,10 +557,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.41.tgz",
-      "integrity": "sha512-Q+eSkdYQJ2XK1AJnr4Ji8Gvk3sRDybEwfTvtL9CA25FFUSD2EgZQewN6VCyWYZCXg5MWZdwogdTNBhlWRcWS1w==",
-      "dev": true
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
+      "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@types/node": "^14.0.5",
     "gluegun": "latest"
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",
-    "@types/node": "^12.12.41",
     "jest": "^24.1.0",
     "prettier": "^1.12.1",
     "ts-jest": "^24.1.0",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^14.0.5",
     "gluegun": "latest"
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",
+    "@types/node": "^12.12.42",
     "jest": "^24.1.0",
     "prettier": "^1.12.1",
     "ts-jest": "^24.1.0",

--- a/src/tests/network-check.test.js
+++ b/src/tests/network-check.test.js
@@ -1,5 +1,0 @@
-const { isNetworkConnected } = require('../struct/index')
-
-test('makes sure that we can tell that our unit tests run somewhere with Internet connection', async () => {
-  expect(await isNetworkConnected()).toBe(true)
-})


### PR DESCRIPTION
## Description

Moved network unit test to the `__tests__` directory, rather than the `src/tests/` directory

## Related Issue

Related to #1 

## Motivation and Context

There was already an existing unit test in the `__tests__` directory, but I missed it initially. All tests should go in this directory.

## Screenshots (if applicable):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New framework or language
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)<!-- this probably only applies to the CLI for adding frameworks or languages, rather than manual additions of frameworks or languages -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the structure and style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ ] There is no duplicate pull request.
- [ X ] My code passes all current tests, and passes new tests that I have written to test it if the current tests do not suffice.
